### PR TITLE
Statically ban `return continue eval("...")`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -62,6 +62,7 @@ elimination from the cases where it was implicitly supported in ES2015. This spe
     <h1>Static Semantics: Early Errors</h1>
     <ul>
       <li>It is a Syntax Error IsInTailPosition of |TailCallExpression| is *false*.</li>
+      <li>It is a Syntax Error if the StringValue of the |MemberExpression| is `eval`.</li>
     </ul>
   </emu-clause>
 
@@ -81,7 +82,6 @@ elimination from the cases where it was implicitly supported in ES2015. This spe
             1. Let _thisValue_ be *undefined*.
           1. Return ? EvaluateDirectCall(_func_, _thisValue_, |Arguments|, *true*).
         </emu-alg>
-        <emu-note>A |TailCallExpression| which calls `eval` will not be a direct eval.</emu-note>
         <emu-grammar>TailCallExpression : `continue` CallExpression Arguments</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |CallExpression|.


### PR DESCRIPTION
Closes #14
